### PR TITLE
Upgrade to KafkaFlow v3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 KafkaFlow MessagePack Serializer is an extension of [Kafka Flow](https://github.com/Farfetch/kafkaflow) that use [MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp) library to optimize message sizes.
 
 ## Requirements
+
 **.NET Core 2.1 and later**
 
 ## NuGet Package
@@ -10,11 +11,37 @@ KafkaFlow MessagePack Serializer is an extension of [Kafka Flow](https://github.
 |---------------------------------|----|
 |KafkaFlow.Serializer.MessagePack|[![Nuget Package](https://img.shields.io/nuget/v/KafkaFlow.Serializer.MessagePack.svg?logo=nuget)](https://www.nuget.org/packages/KafkaFlow.Serializer.MessagePack/) ![Nuget downloads](https://img.shields.io/nuget/dt/KafkaFlow.Serializer.MessagePack.svg)
 
-## Install via NuGet 
-    Install-Package KafkaFlow.Serializer.MessagePack
+## Install via NuGet
 
-## Usage 
-### For a specific message type
+```bash
+Install-Package KafkaFlow.Serializer.MessagePack
+```
+
+## Usage
+
+### Consumer
+
+#### Deserialize a specific message type
+
+```csharp
+.AddMiddlewares(
+    middlewares => middlewares // KafkaFlow middlewares
+    .AddSingleTypeDeserializer<SampleMessage, MessagePackDeserializer>()
+    )
+```
+
+#### Deserialize all message types
+
+```csharp
+.AddMiddlewares(
+    middlewares => middlewares // KafkaFlow middlewares
+    .AddDeserializer<MessagePackDeserializer>()
+    )
+```
+
+### Producer
+
+#### Serialize a specific message type
 
 ```csharp
 .AddMiddlewares(
@@ -23,7 +50,7 @@ KafkaFlow MessagePack Serializer is an extension of [Kafka Flow](https://github.
     )
 ```
 
-### For all message types
+#### Serialize all message types
 
 ```csharp
 .AddMiddlewares(
@@ -37,7 +64,6 @@ See [samples](https://github.com/JotaDobleEse/kafkaflow-messagepack-serializer/t
 ## Maintainers
 
 -   [Jesús Ruiz](https://github.com/JotaDobleEse)
-
 
 ## License
 

--- a/samples/KafkaFlow.Serializer.MessagePack.Sample/KafkaFlow.Serializer.MessagePack.Sample.csproj
+++ b/samples/KafkaFlow.Serializer.MessagePack.Sample/KafkaFlow.Serializer.MessagePack.Sample.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <LangVersion>9</LangVersion>
@@ -17,11 +17,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="KafkaFlow" Version="2.2.13" />
-        <PackageReference Include="KafkaFlow.LogHandler.Console" Version="2.2.13" />
-        <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="2.2.13" />
-        <PackageReference Include="KafkaFlow.Serializer" Version="2.2.13" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.17" />
+        <PackageReference Include="KafkaFlow" Version="3.0.1" />
+        <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.0.1" />
+        <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     </ItemGroup>
 

--- a/samples/KafkaFlow.Serializer.MessagePack.Sample/Program.cs
+++ b/samples/KafkaFlow.Serializer.MessagePack.Sample/Program.cs
@@ -39,7 +39,7 @@
                                     .WithWorkersCount(1)
                                     .AddMiddlewares(
                                         m => m
-                                            .AddSingleTypeSerializer<SampleMessage, MessagePackSerializer>()
+                                            .AddSingleTypeDeserializer<SampleMessage, MessagePackDeserializer>()
                                             .Add<PrintConsoleMiddleware>()
                                     )
                             )

--- a/src/KafkaFlow.Serializer.MessagePack/KafkaFlow.Serializer.MessagePack.csproj
+++ b/src/KafkaFlow.Serializer.MessagePack/KafkaFlow.Serializer.MessagePack.csproj
@@ -24,7 +24,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="KafkaFlow.Abstractions" Version="2.2.13" />
+		<PackageReference Include="KafkaFlow.Abstractions" Version="3.0.1" />
 		<PackageReference Include="MessagePack" Version="2.4.59" />
 	</ItemGroup>
 

--- a/src/KafkaFlow.Serializer.MessagePack/MessagePackDeserializer.cs
+++ b/src/KafkaFlow.Serializer.MessagePack/MessagePackDeserializer.cs
@@ -1,5 +1,6 @@
 ﻿namespace KafkaFlow.Serializer
 {
+    using System;
     using System.IO;
     using System.Threading.Tasks;
     using MessagePack;
@@ -8,7 +9,7 @@
     /// <summary>
     /// A message serializer using MessagePack library
     /// </summary>
-    public class MessagePackSerializer : ISerializer
+    public class MessagePackDeserializer : IDeserializer
     {
         private static readonly IFormatterResolver DefaultResolver = CompositeResolver.Create(
                                                                         NativeDateTimeResolver.Instance,
@@ -17,18 +18,18 @@
         private readonly MessagePackSerializerOptions options;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MessagePackSerializer"/> class.
+        /// Initializes a new instance of the <see cref="MessagePackDeserializer"/> class.
         /// </summary>
         /// <param name="options">MessagePack serializer options</param>
-        public MessagePackSerializer(MessagePackSerializerOptions options)
+        public MessagePackDeserializer(MessagePackSerializerOptions options)
         {
             this.options = options;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MessagePackSerializer"/> class.
+        /// Initializes a new instance of the <see cref="MessagePackDeserializer"/> class.
         /// </summary>
-        public MessagePackSerializer()
+        public MessagePackDeserializer()
             : this(MessagePackSerializerOptions
                                 .Standard
                                 .WithResolver(DefaultResolver)
@@ -37,7 +38,7 @@
         }
 
         /// <inheritdoc/>
-        public Task SerializeAsync(object message, Stream output, ISerializerContext context)
-            => MessagePack.MessagePackSerializer.SerializeAsync(message.GetType(), output, message, this.options);
+        public async Task<object> DeserializeAsync(Stream input, Type type, ISerializerContext context)
+            => await MessagePack.MessagePackSerializer.DeserializeAsync(type, input, this.options);
     }
 }

--- a/src/KafkaFlow.UnitTests/KafkaFlow.Serializer.MessagePack.UnitTests.csproj
+++ b/src/KafkaFlow.UnitTests/KafkaFlow.Serializer.MessagePack.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/KafkaFlow.UnitTests/MessagePackDeserializerTests.cs
+++ b/src/KafkaFlow.UnitTests/MessagePackDeserializerTests.cs
@@ -1,0 +1,45 @@
+namespace KafkaFlow.Serializer.MessagePack.UnitTests
+{
+    using AutoFixture;
+    using FluentAssertions;
+    using global::MessagePack;
+    using global::MessagePack.Resolvers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    [TestClass]
+    public class MessagePackDeserializerTests
+    {
+        private static readonly MessagePackSerializerOptions MessagePackOptions = MessagePackSerializerOptions
+            .Standard
+            .WithResolver(CompositeResolver.Create(
+                NativeDateTimeResolver.Instance,
+                StandardResolverAllowPrivate.Instance))
+            .WithCompression(MessagePackCompression.Lz4BlockArray);
+
+        private Mock<ISerializerContext> contextMock = new();
+
+        private MessagePackDeserializer deserializer = new(MessagePackOptions);
+
+        private Fixture fixture = new();
+
+        [TestMethod]
+        public async Task DeserializeAsync_ValidPayload_ObjectGenerated()
+        {
+            // Arrange
+            var message = fixture.Create<TestMessage>();
+            using var input = new MemoryStream();
+            await MessagePackSerializer.SerializeAsync(message.GetType(), input, message, MessagePackOptions);
+            input.Seek(0, SeekOrigin.Begin);
+
+            // Act
+            var result = await deserializer.DeserializeAsync(input, typeof(TestMessage), contextMock.Object);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<TestMessage>();
+        }
+    }
+}

--- a/src/KafkaFlow.UnitTests/MessagePackSerializerTests.cs
+++ b/src/KafkaFlow.UnitTests/MessagePackSerializerTests.cs
@@ -6,7 +6,6 @@ namespace KafkaFlow.Serializer.MessagePack.UnitTests
     using global::MessagePack.Resolvers;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
-    using System;
     using System.IO;
     using System.Threading.Tasks;
 
@@ -39,39 +38,6 @@ namespace KafkaFlow.Serializer.MessagePack.UnitTests
             // Assert
             output.Length.Should().BeGreaterThan(0);
             output.Position.Should().BeGreaterThan(0);
-        }
-
-        [TestMethod]
-        public async Task DeserializeAsync_ValidPayload_ObjectGenerated()
-        {
-            // Arrange
-            var message = fixture.Create<TestMessage>();
-            using var input = new MemoryStream();
-            await MessagePackSerializer.SerializeAsync(message.GetType(), input, message, MessagePackOptions);
-            input.Seek(0, SeekOrigin.Begin);
-
-            // Act
-            var result = await serializer.DeserializeAsync(input, typeof(TestMessage), contextMock.Object);
-
-            // Assert
-            result.Should().NotBeNull();
-            result.Should().BeOfType<TestMessage>();
-        }
-
-        [MessagePackObject]
-        private class TestMessage
-        {
-            [Key(0)]
-            public int IntegerField { get; set; }
-
-            [Key(1)]
-            public string StringField { get; set; }
-
-            [Key(2)]
-            public double DoubleField { get; set; }
-
-            [Key(3)]
-            public DateTime DateTimeField { get; set; }
         }
     }
 }

--- a/src/KafkaFlow.UnitTests/TestMessage.cs
+++ b/src/KafkaFlow.UnitTests/TestMessage.cs
@@ -1,0 +1,21 @@
+using System;
+using MessagePack;
+
+namespace KafkaFlow.Serializer.MessagePack.UnitTests
+{
+    [MessagePackObject]
+    internal class TestMessage
+    {
+        [Key(0)]
+        public int IntegerField { get; set; }
+
+        [Key(1)]
+        public string StringField { get; set; }
+
+        [Key(2)]
+        public double DoubleField { get; set; }
+
+        [Key(3)]
+        public DateTime DateTimeField { get; set; }
+    }
+}


### PR DESCRIPTION
Bump KafkaFlow version 3.0.

KafkaFlow v3 segregates Serializers into Serialization and Deserialization, which leads to the refactor here.